### PR TITLE
feat: adjust the error return order for client.Do

### DIFF
--- a/client.go
+++ b/client.go
@@ -67,17 +67,16 @@ func (client *Client) Do(req *http.Request, accessToken string) (resp []byte, er
 		return
 	}
 
-	if response.StatusCode != http.StatusOK {
-		err = fmt.Errorf("response.Status %s", response.Status)
-		return
-	}
-
 	resp, err = ioutil.ReadAll(response.Body)
 	if err != nil {
 		return
 	}
+	_ = response.Body.Close()
 
-	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		err = fmt.Errorf("response.Status %s, response.Body %s", response.Status, resp)
+		return
+	}
 
 	return
 }


### PR DESCRIPTION
调整了下报错信息返回顺序，先读取 Body，这样如果 response.StatusCode 不等于 200 的时候返回异常信息可以把 Body 体内容带上，方便调用端调试。